### PR TITLE
get correct html length base on utf-8

### DIFF
--- a/connect/directory.js
+++ b/connect/directory.js
@@ -155,7 +155,7 @@ exports.html = function(req, res, files, directories, next, dir, showUp, icons, 
         .replace('{urlenc-directory}', querystring.escape(dir))
         .replace('{root}', root);
       res.setHeader('Content-Type', 'text/html');
-      res.setHeader('Content-Length', str.length);
+      res.setHeader('Content-Length', Buffer.byteLength(str, 'utf8'));
       res.end(str);
     });
   });


### PR DESCRIPTION
# HTML source code incomplete

When I use chinese in dir name, html page becoming abnormal.

## example

HTTP source code:

```html
...
      <h3 id="search-title" class="hidden"></h3>
      <ul id="files"><li><a href="/" class="" title="..">..</a></li>
<li><a href="/test/文件夹" class="icon" title="文件夹"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQBAMAAADt3eJSAAAAB3RJTUUH0AwNAR0xRgCFQgAAAAlwSFlzAAALEgAACxIB0t1+/AAAABtQTFRFwMDAAAAAn58Az89g///P/8+f//+f8PDw////kPjK0gAAAAF0Uk5TAEDm2GYAAABQSURBVHjaY2CAAyYlJQEwQ73FzRAsYGxsbKSkpMDA5AICQEEmtzQgSIUywsISIYxUqEhYWBiEkQoVAQqEAtW4AvmpoYZgA4EAaLggBDBgAACi3BdHFUhBFAAAAABJRU5ErkJggg==" />文件夹</a></li></ul>
    </div>
```

HTTP package:

```
...
Hypertext Transfer Protocol
    HTTP/1.1 200 OK\r\n
    Content-Type: text/html\r\n
    Content-Length: 18740\r\n
    Date: Sat, 25 Feb 2017 10:20:44 GMT\r\n
    Connection: keep-alive\r\n
    \r\n
    [HTTP response 1/1]
    [Time since request: 0.003788000 seconds]
    [Request in frame: 3743]
    File Data: 18740 bytes
Line-based text data: text/html
Hypertext Transfer Protocol
    Data (18 bytes)
```